### PR TITLE
Add dropout to GRU + no-backprop-truncation optimization

### DIFF
--- a/mygrad/nnet/layers/dense.py
+++ b/mygrad/nnet/layers/dense.py
@@ -28,7 +28,7 @@ class Dense(Operation):
         else:
             # a: (T, N, C)
             # grad: (T, N, D)
-            self.b.backward(np.einsum("ijk,ijl -> kl", self.a.data, grad))
+            self.b.backward(np.tensordot(self.a.data, grad, ((0, 1), (0, 1))))
 
 
 def dense(x, w):

--- a/mygrad/nnet/layers/gru.py
+++ b/mygrad/nnet/layers/gru.py
@@ -25,17 +25,15 @@ def _gru_layer_dropout(s, z, r, h, Wz, Wr, Wh, bz, br, bh, dropz, dropr, droph):
     for n in range(len(s) - 1):
         z[n] += np.dot(s[n], Wz) + bz
         z[n] = (1 / (1 + np.exp(-z[n])))
-        z[n] *= dropz[n]
 
         r[n] += np.dot(s[n], Wr) + br
         r[n] = (1 / (1 + np.exp(-r[n])))
-        r[n] *= dropr[n]
 
-        h[n] += np.dot(r[n] * s[n], Wh) + bh
+        h[n] += np.dot(dropr[n] * r[n] * s[n], Wh) + bh
         h[n] = np.tanh(h[n])
-        h[n] *= droph[n]
 
-        s[n + 1] = (1 - z[n]) * h[n] + z[n] * s[n]
+        zd = dropz[n] * z[n]
+        s[n + 1] = (1 - zd) * droph[n] * h[n] + zd * s[n]
 
 
 class GRUnit(Operation):
@@ -43,7 +41,7 @@ class GRUnit(Operation):
     def __call__(self, X, Uz, Wz, bz, Ur, Wr, br, Uh, Wh, bh, s0=None, bp_lim=None, dropout=0.):
         if bp_lim is not None:
             assert isinstance(bp_lim, Integral) and 0 <= bp_lim < len(X)
-        assert 0. <= dropout <= 1.
+        assert 0. <= dropout < 1.
         self._dropout = dropout
         self.bp_lim = bp_lim if bp_lim is not None else len(X) - 1
 
@@ -100,8 +98,13 @@ class GRUnit(Operation):
 
         return self._hidden_seq
 
-    def _gru_dLds(self, s, z, r, dLds, dz, dh, dr, s_h):
+    def _gru_dLds(self, s, z, r, dLds, dz, dh, dr, s_h, one_z):
         """
+                            Z_{t} = sigmoid(Uz X_{t} + Wz S_{t-1} + bz)
+                            R_{t} = sigmoid(Ur X_{t} + Wr S_{t-1} + br)
+                            H_{t} = tanh(Uh X_{t} + Wh (R{t} * S_{t-1}) + bh)
+                            S_{t} = (1 - Z{t}) * H{t} + Z{t} * S_{t-1}
+
         Returns
         --------
             partial dL / ds(t+1) * ds(t+1) / ds(t) +
@@ -110,10 +113,10 @@ class GRUnit(Operation):
             partial dL / ds(t+1) * ds(t+1) / dh(t) * dh(t) / dr(t) * dr(t) / ds(t)
         """
         Wz, Wr, Wh = self.Wz.data, self.Wr.data, self.Wh.data
+        dLdh = np.dot(dLds * one_z * dh, Wh.T)
 
-        dLdh = np.dot(dLds * dh * dz, Wh.T)
         out = z * dLds
-        out += np.dot(dLds * s_h * z * dz, Wz.T)
+        out += np.dot(dLds * s_h * dz, Wz.T)
         out += dLdh * r
         out += np.dot(dLdh * s * dr, Wr.T)
 
@@ -135,15 +138,20 @@ class GRUnit(Operation):
         if self.bp_lim < len(self.X) - 1:
             old_dLds = np.zeros_like(dLds)
 
-        const = {"1-z": 1 - z,
-                 "1-h**2": 1 - h**2,
-                 "s-h": s - h,
+        const = {"1 - h**2": 1 - h**2,
+                 "z*(1 - z)": z * (1 - z),
                  "r*(1 - r)": r * (1 - r)}
 
         if self._dropout:
-            const["1-h**2"] *= self._droph
+            const["1 - h**2"] *= self._droph
             const["r*(1 - r)"] *= self._dropr
-            const["s-h"] *= self._dropz
+            const["z*(1 - z)"] *= self._dropz
+            h *= self._droph
+            r *= self._dropr
+            z *= self._dropz
+
+        const["s - h"] = s - h
+        const["1 - z"] = 1 - z
 
         for i in range(self.bp_lim):
             #  dL(t) / ds(t) + dL(t+1) / ds(t)
@@ -161,14 +169,15 @@ class GRUnit(Operation):
                                                  z[source_index],
                                                  r[source_index],
                                                  dt,
-                                                 const["1-z"][source_index],
-                                                 const["1-h**2"][source_index],
+                                                 const["z*(1 - z)"][source_index],
+                                                 const["1 - h**2"][source_index],
                                                  const["r*(1 - r)"][source_index],
-                                                 const["s-h"][source_index])
+                                                 const["s - h"][source_index],
+                                                 const["1 - z"][source_index])
 
         zgrad = dLds * (s - h)   # dL / dz
-        hgrad = dLds * const["1-z"]   # dL / dh
-        rgrad = np.dot(const["1-h**2"] * hgrad, self.Wh.data.T) * s  # dL / dr
+        hgrad = dLds * const["1 - z"]   # dL / dh
+        rgrad = np.dot(const["1 - h**2"] * hgrad, self.Wh.data.T) * s  # dL / dr
 
         self._hidden_seq.grad = dLds
         self._z.grad = zgrad
@@ -176,10 +185,7 @@ class GRUnit(Operation):
         self._h.grad = hgrad
 
         if any(not const for const in (self.Uz.constant, self.Wz.constant, self.bz.constant)):
-            dz = zgrad * z * const["1-z"]
-
-            if self._dropout:
-                dz *= self._dropz
+            dz = zgrad * const["z*(1 - z)"]
 
         if not self.Uz.constant:
             self.Uz.backward(np.einsum("ijk, ijl -> kl", self.X.data, dz))
@@ -199,7 +205,7 @@ class GRUnit(Operation):
             self.br.backward(dr.sum(axis=(0, 1)))
 
         if any(not const for const in (self.Uh.constant, self.Wh.constant, self.bh.constant)):
-            dh = hgrad * const["1-h**2"]
+            dh = hgrad * const["1 - h**2"]
 
         if not self.Uh.constant:
             self.Uh.backward(np.einsum("ijk, ijl -> kl", self.X.data, dh))
@@ -209,9 +215,9 @@ class GRUnit(Operation):
             self.bh.backward(dh.sum(axis=(0, 1)))
 
         if not self.X.constant:
-            tmp = dLds * const["1-h**2"] * const["1-z"]
+            tmp = dLds * const["1 - z"] * const["1 - h**2"]
 
-            dLdX = np.dot((dLds * const["s-h"]) * z * const["1-z"], self.Uz.data.T)
+            dLdX = np.dot((dLds * const["s - h"]) * const["z*(1 - z)"], self.Uz.data.T)
             dLdX += np.dot(tmp, self.Uh.data.T)
             dLdX += np.dot(np.dot(tmp, self.Wh.data.T) * s * const["r*(1 - r)"], self.Ur.data.T)
 
@@ -227,10 +233,10 @@ def gru(X, Uz, Wz, bz, Ur, Wr, br, Uh, Wh, bh, s0=None, bp_lim=None, dropout=0.)
     """ Performs a forward pass of sequential data through a Gated Recurrent Unit layer, returning
         the 'hidden-descriptors' arrived at by utilizing the trainable parameters as follows:
 
-                            Z_{t} = sigmoid(Uz X_{t} + Wz S_{t-1} + bz)
-                            R_{t} = sigmoid(Ur X_{t} + Wr S_{t-1} + br)
-                            H_{t} = tanh(Uh X_{t} + Wh (R{t} * S_{t-1}) + bh)
-                            S_{t} = (1 - Z{t}) * H{t} + Z{t} * S_{t-1}
+                    Z_{t} = drop_z * sigmoid(Uz X_{t} + Wz S_{t-1} + bz)
+                    R_{t} = drop_r * sigmoid(Ur X_{t} + Wr S_{t-1} + br)
+                    H_{t} = drop_h * tanh(Uh X_{t} + Wh (R{t} * S_{t-1}) + bh)
+                    S_{t} = (1 - Z{t}) * H{t} + Z{t} * S_{t-1}
 
         Parameters
         ----------
@@ -257,12 +263,13 @@ def gru(X, Uz, Wz, bz, Ur, Wr, br, Uh, Wh, bh, s0=None, bp_lim=None, dropout=0.)
             E.g. `bp_lim=3` will propagate gradients only up to 3 steps backward through the
             recursive sequence.
 
-        dropout : float (default=0.)
-            If non-zero, the expected proportion of layer outputs to be set to zero. Applied
+        dropout : float (default=0.), 0 <= dropout < 1
+            If non-zero, the expected proportion of a layer's outputs to be set to zero. Applied
             to the layers Z, R, and H, - *not* S.
 
             These layers are also scaled by 1 / dropout, such that the test-time forward pass
             of the gru-layer can be executed without dropout, and with no additional scaling.
+            (only if `dropout` is non-zero)
 
         Returns
         -------

--- a/mygrad/nnet/layers/gru.py
+++ b/mygrad/nnet/layers/gru.py
@@ -40,23 +40,6 @@ def _gru_dLds(s, z, r, h, dLds, Wz, Wr, Wh):
            np.dot(dLdh * s * r * (1 - r), Wr.T)
 
 
-def _gru_dLdx(s, z, r, h, dLds, Uz, Ur, Uh):
-    """
-    Returns
-    --------
-        partial dL / ds(t+1) * ds(t+1) / dz(t) * dz(t) / ds(t) +
-        partial dL / ds(t+1) * ds(t+1) / dh(t) * dh(t) / ds(t) +
-        partial dL / ds(t+1) * ds(t+1) / dh(t) * dh(t) / dr(t) * dr(t) / ds(t)
-    """
-    dz = 1 - z  # note: not actually derivative of sigmoid
-    dh = 1 - h ** 2
-    dLdh = np.dot(dLds * dh * dz, Uh.T)
-
-    return np.dot((dLds * (s - h)) * z * dz, Uz.T) + \
-           dLdh * r + \
-           np.dot(dLdh * s * r * (1 - r), Ur.T)
-
-
 class GRUnit(Operation):
     def __call__(self, X, Uz, Wz, bz, Ur, Wr, br, Uh, Wh, bh, s0=None, bp_lim=None):
         if bp_lim is not None:

--- a/mygrad/nnet/layers/gru.py
+++ b/mygrad/nnet/layers/gru.py
@@ -131,7 +131,7 @@ class GRUnit(Operation):
         h = self._h.data
 
         dLds = grad[1:]
-        if self.bp_lim < len(self.X):
+        if self.bp_lim < len(self.X) or True:
             old_dLds = np.zeros_like(dLds)
 
         const = {"1-z": 1 - z,
@@ -146,7 +146,7 @@ class GRUnit(Operation):
 
         for i in range(self.bp_lim):
             #  dL(t) / ds(t) + dL(t+1) / ds(t)
-            if self.bp_lim < len(self.X):
+            if self.bp_lim < len(self.X) or True:
                 source_index = slice(1, len(dLds) - i)
                 target_index = slice(None, len(dLds) - (i + 1))
                 dt = dLds[source_index] - old_dLds[source_index]
@@ -188,7 +188,7 @@ class GRUnit(Operation):
             self.bz.backward(dz.sum(axis=(0, 1)))
 
         if any(not const for const in (self.Ur.constant, self.Wr.constant, self.br.constant)):
-            dr = rgrad * r * const["r*(1 - r)"]
+            dr = rgrad * const["r*(1 - r)"]
 
         if not self.Ur.constant:
             self.Ur.backward(np.einsum("ijk, ijl -> kl", self.X.data, dr))

--- a/mygrad/nnet/layers/gru.py
+++ b/mygrad/nnet/layers/gru.py
@@ -188,9 +188,9 @@ class GRUnit(Operation):
             dz = zgrad * const["z*(1 - z)"]
 
         if not self.Uz.constant:
-            self.Uz.backward(np.einsum("ijk, ijl -> kl", self.X.data, dz))
+            self.Uz.backward(np.tensordot(self.X.data, dz, ([0, 1], [0, 1])))
         if not self.Wz.constant:
-            self.Wz.backward(np.einsum("ijk, ijl -> kl", s, dz))
+            self.Wz.backward(np.tensordot(s, dz, ([0, 1], [0, 1])))
         if not self.bz.constant:
             self.bz.backward(dz.sum(axis=(0, 1)))
 
@@ -198,9 +198,9 @@ class GRUnit(Operation):
             dr = rgrad * const["r*(1 - r)"]
 
         if not self.Ur.constant:
-            self.Ur.backward(np.einsum("ijk, ijl -> kl", self.X.data, dr))
+            self.Ur.backward(np.tensordot(self.X.data, dr, ([0, 1], [0, 1])))
         if not self.Wr.constant:
-            self.Wr.backward(np.einsum("ijk, ijl -> kl", s, dr))
+            self.Wr.backward(np.tensordot(s, dr, ([0, 1], [0, 1])))
         if not self.br.constant:
             self.br.backward(dr.sum(axis=(0, 1)))
 
@@ -208,9 +208,9 @@ class GRUnit(Operation):
             dh = hgrad * const["1 - h**2"]
 
         if not self.Uh.constant:
-            self.Uh.backward(np.einsum("ijk, ijl -> kl", self.X.data, dh))
+            self.Uh.backward(np.tensordot(self.X.data, dh, ([0, 1], [0, 1])))
         if not self.Wh.constant:
-            self.Wh.backward(np.einsum("ijk, ijl -> kl", (s * r), dh))
+            self.Wh.backward(np.tensordot((s * r), dh, ([0, 1], [0, 1])))
         if not self.bh.constant:
             self.bh.backward(dh.sum(axis=(0, 1)))
 

--- a/tests/test_gru.py
+++ b/tests/test_gru.py
@@ -158,7 +158,7 @@ def test_gru_backward(data, choice):
                              elements=st.floats(-10, 10)))
     T, N, C = X.shape
     D = choice(list(range(1, 5)))
-    dropout = 0#choice([0, .33])
+    dropout = choice([0, .33])
 
     Wz = data.draw(hnp.arrays(shape=(D, D),
                              dtype=float,
@@ -285,5 +285,6 @@ def test_gru_backward(data, choice):
     assert np.allclose(X.grad, X2.grad)
 
     ls.null_gradients()
+    ls2.null_gradients()
     for x in [s, Wz, Wr, Wh, bz, br, bh, X, Uz, Ur, Uh, V]:
         assert x.grad is None

--- a/tests/test_gru.py
+++ b/tests/test_gru.py
@@ -9,9 +9,139 @@ import hypothesis.extra.numpy as hnp
 
 import numpy as np
 
+@given(st.data(), st.choices())
+def test_gru_fwd(data, choice):
+    X = data.draw(hnp.arrays(shape=hnp.array_shapes(max_side=5, min_dims=3, max_dims=3),
+                             dtype=float,
+                             elements=st.floats(-10, 10)))
+    T, N, C = X.shape
+    D = choice(list(range(1, 5)))
+
+
+    Wz = data.draw(hnp.arrays(shape=(D, D),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    Uz = data.draw(hnp.arrays(shape=(C, D),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    bz = data.draw(hnp.arrays(shape=(D,),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    Wr = data.draw(hnp.arrays(shape=(D, D),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    Ur = data.draw(hnp.arrays(shape=(C, D),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    br = data.draw(hnp.arrays(shape=(D,),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    Wh = data.draw(hnp.arrays(shape=(D, D),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    Uh = data.draw(hnp.arrays(shape=(C, D),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    bh = data.draw(hnp.arrays(shape=(D,),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+    V = data.draw(hnp.arrays(shape=(D, C),
+                             dtype=float,
+                             elements=st.floats(-10.0, 10.0)))
+
+
+    s0 = np.zeros((N, D), dtype=float)
+
+    X = Tensor(X)
+    X2 = X.__copy__()
+
+    Wz = Tensor(Wz)
+    Wz2 = Wz.__copy__()
+
+    Uz = Tensor(Uz)
+    Uz2 = Uz.__copy__()
+
+    bz = Tensor(bz)
+    bz2 = bz.__copy__()
+
+    Wr = Tensor(Wr)
+    Wr2 = Wr.__copy__()
+
+    Ur = Tensor(Ur)
+    Ur2 = Ur.__copy__()
+
+    br = Tensor(br)
+    br2 = br.__copy__()
+
+    Wh = Tensor(Wh)
+    Wh2 = Wh.__copy__()
+
+    Uh = Tensor(Uh)
+    Uh2 = Uh.__copy__()
+
+    bh = Tensor(bh)
+    bh2 = bh.__copy__()
+
+    V = Tensor(V)
+    V2 = V.__copy__()
+
+    s0 = Tensor(s0)
+    s2 = s0.__copy__()
+
+    s = gru(X, Uz, Wz, bz, Ur, Wr, br, Uh, Wh, bh)
+    o = dense(s[1:], V)
+    ls = o.sum()
+
+    stt = s2
+    all_s = [s0.data]
+    ls2 = 0
+    for n, x in enumerate(X2):
+        z = sigmoid(dense(x, Uz2) + dense(stt, Wz2) + bz2)
+        r = sigmoid(dense(x, Ur2) + dense(stt, Wr2) + br2)
+        h = tanh(dense(x, Uh2) + dense((r * stt), Wh2) + bh2)
+        stt = (1 - z) * h + z * stt
+        all_s.append(stt)
+        o = dense(stt, V2)
+        ls2 += o.sum()
+
+    rec_s_dat = np.stack([i.data for i in all_s])
+
+    assert np.allclose(ls.data, ls2.data)
+
+    assert np.allclose(rec_s_dat, s.data)
+
+    assert np.allclose(Wz.data, Wz2.data)
+    assert np.allclose(Wr.data, Wr2.data)
+    assert np.allclose(Wh.data, Wh2.data)
+
+    assert np.allclose(Uz.data, Uz2.data)
+    assert np.allclose(Ur.data, Ur2.data)
+    assert np.allclose(Uh.data, Uh2.data)
+
+    assert np.allclose(bz.data, bz2.data)
+    assert np.allclose(br.data, br2.data)
+    assert np.allclose(bh.data, bh2.data)
+
+    assert np.allclose(V.data, V2.data)
+
+    assert np.allclose(X.data, X2.data)
+
+    ls.null_gradients()
+    for x in [s, Wz, Wr, Wh, bz, br, bh, X, Uz, Ur, Uh, V]:
+        assert x.grad is None
+
 
 @given(st.data(), st.choices())
-def test_gru(data, choice):
+def test_gru_backward(data, choice):
     X = data.draw(hnp.arrays(shape=hnp.array_shapes(max_side=5, min_dims=3, max_dims=3),
                              dtype=float,
                              elements=st.floats(-10, 10)))
@@ -117,42 +247,24 @@ def test_gru(data, choice):
         ls2 += o.sum()
     ls2.backward()
 
-    rec_s_dat = np.stack([i.data for i in all_s])
     rec_s_grad = np.stack([i.grad for i in all_s[1:]])
 
-    assert np.allclose(ls.data, ls2.data)
-
-    assert np.allclose(rec_s_dat, s.data)
     assert np.allclose(rec_s_grad, s.grad)
-
-    assert np.allclose(Wz.data, Wz2.data)
-    assert np.allclose(Wr.data, Wr2.data)
-    assert np.allclose(Wh.data, Wh2.data)
 
     assert np.allclose(Wz.grad, Wz2.grad)
     assert np.allclose(Wr.grad, Wr2.grad)
     assert np.allclose(Wh.grad, Wh2.grad)
 
-    assert np.allclose(Uz.data, Uz2.data)
-    assert np.allclose(Ur.data, Ur2.data)
-    assert np.allclose(Uh.data, Uh2.data)
-
     assert np.allclose(Uz.grad, Uz2.grad)
     assert np.allclose(Ur.grad, Ur2.grad)
     assert np.allclose(Uh.grad, Uh2.grad)
-
-    assert np.allclose(bz.data, bz2.data)
-    assert np.allclose(br.data, br2.data)
-    assert np.allclose(bh.data, bh2.data)
 
     assert np.allclose(bz.grad, bz2.grad)
     assert np.allclose(br.grad, br2.grad)
     assert np.allclose(bh.grad, bh2.grad)
 
-    assert np.allclose(V.data, V2.data)
     assert np.allclose(V.grad, V2.grad)
 
-    assert np.allclose(X.data, X2.data)
     assert np.allclose(X.grad, X2.grad)
 
     ls.null_gradients()


### PR DESCRIPTION
`mygrad.nnet.layers.gru` now supports dropout on `z`, `r`, and `h`. Additionally, a major optimization is now available if back propagation through time is not truncated.

Still need to add a unit test for truncated backprop

einsum -> tensorfot for optimization